### PR TITLE
Integrate celery to support asynchronous tasks

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,7 @@ services:
          - 443:443
       depends_on:
          - mysql
+         - rabbitmq
       environment:
          - MYSQL_USER=root
          - MYSQL_PASSWORD=password12345
@@ -16,6 +17,7 @@ services:
          - GOOGLE_SECRET=/usr/local/etc/google_secret.json
       volumes:
           - ./data/ssl:/etc/apache2/ssl
+          - ./log:/log
       restart: always
 
    mysql:
@@ -28,3 +30,12 @@ services:
       volumes:
          - ./data/mysql:/var/lib/mysql
       restart: always
+
+   rabbitmq:
+      image: rabbitmq:3-management
+      restart: always
+      ports:
+         - "35672:5672"
+         - "15672:15672"
+      volumes:
+         - ./install/rabbitmq.config:/etc/rabbitmq/rabbitmq.config:ro

--- a/install/rabbitmq.config
+++ b/install/rabbitmq.config
@@ -1,0 +1,13 @@
+[
+    { rabbit, [
+        { loopback_users, [ ] },
+        { tcp_listeners, [ 5672 ] },
+        { ssl_listeners, [ ] },
+        { hipe_compile, false },
+        { heartbeat, 2600 }
+    ] },
+    { rabbitmq_management, [ { listener, [
+        { port, 15672 },
+        { ssl, false }
+    ] } ] }
+].

--- a/install/requirements.txt
+++ b/install/requirements.txt
@@ -5,3 +5,5 @@ capstone
 httplib2
 oauth2client
 google-api-python-client
+celery
+django-celery-results

--- a/install/run.sh
+++ b/install/run.sh
@@ -1,18 +1,6 @@
 #!/bin/bash
 
-# Wait for the MySQL service to become available
-while [ true ]; do
-   echo "show databases" | mysql -h $MYSQL_HOST -u $MYSQL_USER --password=$MYSQL_PASSWORD &> /dev/null
-
-   if [ $? != 0 ]; then
-      echo "Waiting for MySQL to become available"
-      sleep 3
-   else
-      break
-   fi
-done
-
-# Finally, make sure we have an SSL certificate in place
+# Make sure we have an SSL certificate in place
 if [ ! -e /etc/apache2/ssl/apache.crt ]; then
    echo "Generating new SSL certificate"
    openssl req -subj '/CN=example.com/O=First/C=US' -new -newkey rsa:4096 -sha256 -days 365 -nodes -x509 -keyout /etc/apache2/ssl/apache.key -out /etc/apache2/ssl/apache.crt
@@ -35,12 +23,33 @@ do
     fi
 done
 
+# Wait for the MySQL service to become available
+while [ true ]; do
+   echo "show databases" | mysql -h $MYSQL_HOST -u $MYSQL_USER --password=$MYSQL_PASSWORD &> /dev/null
+
+   if [ $? != 0 ]; then
+      echo "Waiting for MySQL to become available"
+      sleep 3
+   else
+      break
+   fi
+done
+
+# Wait for RabbitMQ to be up
+# TODO Don't hardcode port
+while ! nc -w -1 -z rabbitmq 5672
+do
+    echo "Waiting for RabbitMQ to become available"
+    sleep 3
+done
+
 # Always run migrations
 /usr/bin/python /home/first/manage.py makemigrations
 /usr/bin/python /home/first/manage.py migrate
+/usr/bin/python /home/first/manage.py migrate django_celery_results
 
 # Collect static files
-/usr/bin/python /home/first/manage.py collectstatic
+/usr/bin/python /home/first/manage.py collectstatic --no-input
 
 # Finally, start up the apache service
 /usr/sbin/apache2ctl -D FOREGROUND

--- a/install/supervisor/celery.conf
+++ b/install/supervisor/celery.conf
@@ -1,0 +1,5 @@
+[program:celery]
+command=celery -A first:celery_app worker -Ofair --concurrency 5 --loglevel DEBUG --logfile /log/celery.log
+directory=/home/first
+redirect_stderr=true
+stdout_logfile=/log/celery_worker.log

--- a/install/supervisor/supervisord.conf
+++ b/install/supervisor/supervisord.conf
@@ -1,0 +1,29 @@
+; supervisor config file
+
+[unix_http_server]
+file=/var/run/supervisor.sock                       ; path to your socket file
+
+[supervisord]
+logfile=/log/supervisord.log ; (main log file;default $CWD/supervisord.log)
+pidfile=/var/run/supervisord.pid ; (supervisord pidfile;default supervisord.pid)
+childlogdir=/var/log/supervisor            ; ('AUTO' child log dir, default $TEMP)
+nodaemon=true
+
+; the below section must remain in the config file for RPC
+; (supervisorctl/web interface) to work, additional interfaces may be
+; added by defining them in separate rpcinterface: sections
+[rpcinterface:supervisor]
+supervisor.rpcinterface_factory = supervisor.rpcinterface:make_main_rpcinterface
+
+[supervisorctl]
+serverurl=unix:///var/run/supervisor.sock ; use a unix:// URL  for a unix socket
+
+; The [include] section can just contain the "files" setting.  This
+; setting can list multiple files (separated by whitespace or
+; newlines).  It can also contain wildcards.  The filenames are
+; interpreted as relative to this file.  Included files *cannot*
+; include files themselves.
+
+[include]
+files = /etc/supervisor/conf.d/*.conf
+

--- a/install/supervisor/webserver.conf
+++ b/install/supervisor/webserver.conf
@@ -1,0 +1,4 @@
+[program:webserver]
+command=/usr/local/bin/run.sh
+redirect_stderr=true
+stdout_logfile=/log/webserver_server.log

--- a/server/first/__init__.py
+++ b/server/first/__init__.py
@@ -1,0 +1,8 @@
+from __future__ import absolute_import, unicode_literals
+
+# This will make sure the app is always imported when
+# Django starts so that shared_task will use this app.
+from .celery import app as celery_app
+
+__all__ = ['celery_app']
+

--- a/server/first/celery.py
+++ b/server/first/celery.py
@@ -1,0 +1,22 @@
+from __future__ import absolute_import, unicode_literals
+import os
+from celery import Celery
+
+# set the default Django settings module for the 'celery' program.
+os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'first.settings')
+
+app = Celery('first')
+
+# Using a string here means the worker doesn't have to serialize
+# the configuration object to child processes.
+# - namespace='CELERY' means all celery-related configuration keys
+#   should have a `CELERY_` prefix.
+app.config_from_object('django.conf:settings', namespace='CELERY')
+
+# Load task modules from all registered Django app configs.
+app.autodiscover_tasks()
+
+
+@app.task(bind=True)
+def debug_task(self):
+    print('Request: {0!r}'.format(self.request))

--- a/server/first/settings.py
+++ b/server/first/settings.py
@@ -57,6 +57,7 @@ INSTALLED_APPS = [
     'django.contrib.sessions',
     'django.contrib.messages',
     'django.contrib.staticfiles',
+    'django_celery_results',
 ] + CONFIG.get('installed_apps', [])
 
 MIDDLEWARE = [
@@ -146,3 +147,7 @@ USE_TZ = CONFIG.get('use_tz', True)
 STATIC_ROOT = CONFIG.get('static_root', os.path.join(BASE_DIR, 'static'))
 
 STATIC_URL = CONFIG.get('static_url', '/static/')
+
+CELERY_BROKER_URL = "amqp://rabbitmq"
+CELERY_RESULT_BACKEND = "django-db"
+CELERY_ENABLE_UTC = True


### PR DESCRIPTION
Integrates celery into FIRST to support the execution of
asynchronous tasks.  Also:
 - Adds 'apt-get clean' to the Dockerfile to avoid these
   errors, which I was encountering occasionally:

   Err:118 http://security.ubuntu.com/ubuntu xenial-security/main amd64 mysql-common all 5.7.21-0ubuntu0.16.04.1
      404  Not Found [IP: 91.189.88.149 80]

 - Adds '--no-input' to 'python manage.py collectstatic' to avoid errors
   sometimes overwriting /home/first

 - Moves the DB ready check below the app requirements installation
   to improve webserver start-up time